### PR TITLE
fix: Resolve profile image upload toast persistence issue

### DIFF
--- a/src/components/ProfileSetting.tsx
+++ b/src/components/ProfileSetting.tsx
@@ -168,17 +168,19 @@ export const ProfileSetting = ({ initialProfile }: ProfileSettingProps) => {
       })
 
       if (result.error) {
+        toast.dismiss() // Clear loading toast first
         toast.error(result.error)
       } else if (result.url) {
         setFileContent(result.url)
+        toast.dismiss() // Clear loading toast first
         toast.success('Profile image updated successfully!')
         router.refresh()
       }
     } catch (error) {
+      toast.dismiss() // Clear loading toast first
       toast.error('Failed to upload image')
     } finally {
       setModalOpen(false)
-      toast.dismiss()
     }
   }
 


### PR DESCRIPTION
fixing: #248

- Add toast.dismiss() calls before showing success/error messages
- Ensure loading toast is properly cleared in all scenarios
- Improve user experience with clear toast state transitions
- Fix overlapping toast notifications during image upload

Resolves: Profile image upload toast message not disappearing after completion